### PR TITLE
Add Tender module with CRUD operations and isStartup integration

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -13,6 +13,7 @@ import { CloudinaryModule } from './core/module/cloudinary/cloudinary.module';
 import { MarketTypeModule } from './module/market-type/market-type.module';
 import { CategoryModule } from './module/category/category.module';
 import { AnnouncerModule } from './module/announcer/announcer.module';
+import { TenderModule } from './module/tender/tender.module';
 
 @Module({
   imports: [
@@ -24,6 +25,7 @@ import { AnnouncerModule } from './module/announcer/announcer.module';
     MarketTypeModule,
     CategoryModule,
     AnnouncerModule,
+    TenderModule,
   ],
 
   providers: [

--- a/src/models/announcer.entity.ts
+++ b/src/models/announcer.entity.ts
@@ -12,4 +12,7 @@ export class Announcer extends AbstractSchema {
 
     @Prop()
     imageUrl: string;
+
+    @Prop({ default: false })
+    isStartup: boolean;
 }

--- a/src/models/tender.entity.ts
+++ b/src/models/tender.entity.ts
@@ -1,0 +1,45 @@
+import { Schema as KSchema, Prop } from "@nestjs/mongoose";
+import { AbstractSchema } from "./abstract-schema";
+import { Schema } from "mongoose";
+import { Announcer } from "./announcer.entity";
+import { Category } from "./category.entity";
+import { MarketType } from "./market-type.entity";
+import { NewsPaper } from "./news-paper.entity";
+
+
+@KSchema({
+    timestamps: true
+})
+export class Tender extends AbstractSchema {
+    @Prop()
+    title: string;
+
+    @Prop({ type: Schema.Types.ObjectId, ref: Announcer.name })
+    announcer: Announcer;
+
+    @Prop({ type: Schema.Types.ObjectId, ref: Category.name })
+    category: Category;
+
+    @Prop({ type: Schema.Types.ObjectId, ref: MarketType.name })
+    marketType: MarketType;
+
+    @Prop()
+    deadline: Date;
+
+    @Prop({
+        type: [{
+            imageUrls: [String],
+            newsPaper: { type: Schema.Types.ObjectId, ref: NewsPaper.name }
+        }],
+        default: [],
+        _id: false
+    })
+    sources: {
+        imageUrls: string[];
+        newsPaper: NewsPaper;
+    }[]
+
+    @Prop({ default: false })
+    isStartup: boolean;
+
+}

--- a/src/module/announcer/announcer.controller.ts
+++ b/src/module/announcer/announcer.controller.ts
@@ -44,9 +44,9 @@ export class AnnouncerController {
     @Body() body: CreateAnnouncerBodyDTO,
     @UploadedFile() image: Express.Multer.File
   ) {
-    const { name, about } = body;
+    const { name, about, isStartup } = body;
 
-    const data = await this.announcerService.create({ name, image, about });
+    const data = await this.announcerService.create({ name, image, about, isStartup });
 
     return ApiResult.success({ data });
   }
@@ -62,10 +62,10 @@ export class AnnouncerController {
     @Body() body: UpdateAnnouncerBodyDTO,
     @UploadedFile() image: Express.Multer.File
   ) {
-    const { name, about } = body;
+    const { name, about, isStartup } = body;
     const id = new Types.ObjectId(params.id);
 
-    const data = await this.announcerService.update(id, { name, image, about });
+    const data = await this.announcerService.update(id, { name, image, about, isStartup });
 
     return ApiResult.success({ data });
   }

--- a/src/module/announcer/announcer.service.ts
+++ b/src/module/announcer/announcer.service.ts
@@ -42,12 +42,13 @@ export class AnnouncerService {
         name: string;
         about: string;
         image: Express.Multer.File;
+        isStartup?: boolean;
     }) => {
-        const { name, about, image } = data;
+        const { name, about, image, isStartup } = data;
 
         await this.checkExistence(name);
 
-        const announcer = new this.announcerModel({ name, about });
+        const announcer = new this.announcerModel({ name, about, isStartup });
 
         const imageUrl = await this.cloudinaryService.uploadImage(image, {
             name: announcer._id.toHexString(),
@@ -63,8 +64,9 @@ export class AnnouncerService {
         name?: string;
         about?: string;
         image?: Express.Multer.File;
+        isStartup?: boolean;
     }) => {
-        const { name, about, image } = data;
+        const { name, about, image , isStartup } = data;
 
         const announcer = await this.getById(id);
 
@@ -82,6 +84,8 @@ export class AnnouncerService {
             });
             announcer.imageUrl = imageUrl;
         }
+
+        if (isStartup !== undefined) announcer.isStartup = isStartup;
 
         if (announcer.isModified()) return await announcer.save();
     }

--- a/src/module/announcer/dto/create-announcer.dto.ts
+++ b/src/module/announcer/dto/create-announcer.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from "@nestjs/swagger";
-import { IsOptional, IsString } from "class-validator";
+import { IsBoolean, IsOptional, IsString } from "class-validator";
 
 export class CreateAnnouncerBodyDTO {
     /**
@@ -23,6 +23,15 @@ export class CreateAnnouncerBodyDTO {
     @IsOptional()
     @ApiProperty({ type: 'string', format: 'binary' })
     image: Express.Multer.File;
+
+    /**
+     * Is the announcer a startup
+     * @example false
+     */
+    @IsOptional()
+    @IsBoolean()
+    isStartup?: boolean;
+
 
 }
 

--- a/src/module/category/sub-category.service.ts
+++ b/src/module/category/sub-category.service.ts
@@ -28,7 +28,8 @@ export class SubCategoryService {
 
         const category = new this.subCategoryModel({ name: name, category: categoryId });
 
-        return await category.save();
+        await category.save();
+        return await this.getById(category._id);
     }
 
     async updateCategory(id: Types.ObjectId, data: {
@@ -53,7 +54,10 @@ export class SubCategoryService {
     }
 
     async getById(id: Types.ObjectId) {
-        const result = await this.subCategoryModel.findById(id);
+        const result = await this.subCategoryModel
+            .findById(id)
+            .populate('category');
+
         if (!result) throw new HttpException('Category not found', 404);
 
         return result;

--- a/src/module/tender/dto/create-tender.dto.ts
+++ b/src/module/tender/dto/create-tender.dto.ts
@@ -1,0 +1,73 @@
+import { ApiProperty } from "@nestjs/swagger";
+import { Type } from "class-transformer";
+import { IsArray, IsBoolean, IsDateString, IsMongoId, IsOptional, IsString, Validate, ValidateNested } from "class-validator";
+
+
+class SourceDTO {
+    /**
+     * News paper ID
+     * @example "Source Name"
+     */
+    @IsMongoId()
+    newsPaper: string;
+
+    /**
+     * Images of the source
+     */
+    @ApiProperty({ type: 'array', items: { type: 'string', format: 'binary' }, required: true })
+    images: Express.Multer.File[];
+}
+
+export class CreateTenderBody {
+    /**
+     * Title of the tender
+     * @example "Tender Title"
+     */
+    @IsString()
+    title: string;
+
+    /**
+     * Announcer of the tender
+     * @example "Announcer ID"
+     */
+    @IsMongoId()
+    announcer: string;
+
+    /**
+     * Category of the tender
+     * @example "Category ID"
+     */
+    @IsMongoId()
+    category: string;
+
+    /**
+     * Market type of the tender
+     * @example "Market Type ID"
+     */
+    @IsMongoId()
+    marketType: string;
+
+    /**
+     * Deadline of the tender (ISO 8601)
+     * @example 2024-12-17T22:11:42.153+00:00
+     */
+    @IsDateString()
+    deadline: string;
+
+    /**
+     * Sources of the tender
+     */
+    @ValidateNested({ each: true })
+    @Type(() => SourceDTO)
+    sources: SourceDTO[];
+
+    /**
+     * is the tender a startup tender
+     */
+    @IsOptional()
+    @IsBoolean()
+    isStartup?: boolean;
+
+}
+
+

--- a/src/module/tender/dto/list-tender.dto.ts
+++ b/src/module/tender/dto/list-tender.dto.ts
@@ -1,0 +1,39 @@
+import { IsBoolean, IsMongoId, IsOptional } from "class-validator";
+import { PaginationQueryDto } from "src/core/shared/dtos/pagination.dto";
+
+export class ListTenderQuery extends PaginationQueryDto {
+
+    /**
+     * Select specific category
+     */
+    @IsOptional()
+    @IsMongoId()
+    category?: string;
+
+    /**
+     * Select specific market type
+     */
+    @IsOptional()
+    @IsMongoId()
+    marketType?: string;
+
+    /**
+     * Select specific announcer
+     */
+    @IsOptional()
+    @IsMongoId()
+    announcer?: string;
+
+    /**
+     * Select tenders with deadline greater than or equal to this date
+     */
+    @IsOptional()
+    deadline?: Date;
+
+    /**
+     * Select startup tenders
+     */
+    @IsOptional()
+    @IsBoolean()
+    startup?: boolean;
+}

--- a/src/module/tender/dto/update-tender.dto.ts
+++ b/src/module/tender/dto/update-tender.dto.ts
@@ -1,0 +1,7 @@
+import { PartialType } from "@nestjs/swagger";
+import { IdParamDto } from "src/core/shared/dtos/id-param.dto";
+import { CreateTenderBody } from "./create-tender.dto";
+
+export class UpdateTenderParams extends IdParamDto{}
+
+export class UpdateTenderBody extends PartialType(CreateTenderBody){}

--- a/src/module/tender/tender.controller.ts
+++ b/src/module/tender/tender.controller.ts
@@ -1,0 +1,133 @@
+import { Body, Controller, Delete, Get, Param, Patch, Post, Query, UploadedFiles, UseInterceptors } from '@nestjs/common';
+import { TenderService } from './tender.service';
+import { CreateTenderBody } from './dto/create-tender.dto';
+import { Types } from 'mongoose';
+import { ApiResult } from 'src/core/types/api-response';
+import { AnyFilesInterceptor } from '@nestjs/platform-express';
+import { ApiConsumes } from '@nestjs/swagger';
+import { UpdateTenderBody, UpdateTenderParams } from './dto/update-tender.dto';
+import { ListTenderQuery } from './dto/list-tender.dto';
+import { IdParamDto } from 'src/core/shared/dtos/id-param.dto';
+
+@Controller('tender')
+export class TenderController {
+  constructor(private readonly tenderService: TenderService) { }
+
+  /**
+   * CREATE TENDER
+   */
+  @ApiConsumes('multipart/form-data')
+
+  @UseInterceptors(AnyFilesInterceptor())
+  @Post()
+  async createTender(
+    @Body() body: CreateTenderBody,
+    @UploadedFiles() files: Array<Express.Multer.File>,
+  ) {
+
+    const { title, isStartup } = body;
+
+    const announcer = new Types.ObjectId(body.announcer);
+    const category = new Types.ObjectId(body.category);
+    const marketType = new Types.ObjectId(body.marketType);
+    const deadline = new Date(body.deadline);
+    const sources = body.sources.map(source => ({ //* Show POSTMAN
+      images: files.filter(image => image.fieldname === `sources[${body.sources.indexOf(source)}][images]`),
+      newsPaper: new Types.ObjectId(source.newsPaper),
+    }));
+
+
+    const tender = await this.tenderService.create({
+      isStartup,
+      title,
+      announcer,
+      category,
+      marketType,
+      deadline,
+      sources,
+    });
+
+    return ApiResult.success({ data: tender });
+  }
+
+  /**
+   * UPDATE TENDER
+   */
+  @ApiConsumes('multipart/form-data')
+  @UseInterceptors(AnyFilesInterceptor())
+  @Patch(':id')
+  async updateTender(
+    @Param() params: UpdateTenderParams,
+    @Body() body: UpdateTenderBody,
+    @UploadedFiles() files: Array<Express.Multer.File>,
+  ) {
+
+    const { title, isStartup } = body;
+
+    const announcer = new Types.ObjectId(body.announcer);
+    const category = new Types.ObjectId(body.category);
+    const marketType = new Types.ObjectId(body.marketType);
+    const deadline = new Date(body.deadline);
+    const sources = body.sources.map(source => ({ //* Show POSTMAN
+      images: files.filter(image => image.fieldname === `sources[${body.sources.indexOf(source)}][images]`),
+      newsPaper: new Types.ObjectId(source.newsPaper),
+    }));
+
+    const tender = await this.tenderService.update(
+      new Types.ObjectId(params.id),
+      {
+        isStartup,
+        title,
+        announcer,
+        category,
+        marketType,
+        deadline,
+        sources,
+      });
+
+    return ApiResult.success({ data: tender });
+  }
+
+  /**
+   * GET TENDERS (WITH FILTERS)
+   */
+  @Get()
+  async getTenders(
+    @Query() query: ListTenderQuery,
+  ) {
+    const { category, marketType, announcer, deadline, startup, keyword, limit, page, sort, fields } = query;
+
+    const result = await this.tenderService.findAll(
+      {
+        category: category ? new Types.ObjectId(category) : undefined,
+        marketType: marketType ? new Types.ObjectId(marketType) : undefined,
+        announcer: announcer ? new Types.ObjectId(announcer) : undefined,
+        deadline: deadline ? new Date(deadline) : undefined,
+        startup,
+      },
+      {
+        keyword, sort, fields,
+      },
+      {
+        page: page ? Number(page) : 1,
+        limit: limit ? Number(limit) : 10,
+      }
+    );
+
+    return ApiResult.success(result);
+  }
+
+  /**
+   * DELETE TENDER
+   */
+  @Delete(':id')
+  async deleteTender(
+    @Param() params: IdParamDto,
+  ) {
+    await this.tenderService.delete(new Types.ObjectId(params.id));
+    return ApiResult.success({ message: 'Tender deleted successfully' });
+  }
+
+
+
+}

--- a/src/module/tender/tender.module.ts
+++ b/src/module/tender/tender.module.ts
@@ -1,0 +1,16 @@
+import { Module } from '@nestjs/common';
+import { TenderService } from './tender.service';
+import { TenderController } from './tender.controller';
+import { DatabaseModule } from 'src/core/module/database.module';
+import { Tender } from 'src/models/tender.entity';
+import { CloudinaryModule } from 'src/core/module/cloudinary/cloudinary.module';
+
+@Module({
+  imports: [
+    DatabaseModule.forFeature([Tender]),
+    CloudinaryModule,
+  ],
+  controllers: [TenderController],
+  providers: [TenderService],
+})
+export class TenderModule { }

--- a/src/module/tender/tender.service.ts
+++ b/src/module/tender/tender.service.ts
@@ -1,0 +1,144 @@
+import { Injectable } from '@nestjs/common';
+import { InjectModel } from '@nestjs/mongoose';
+import { PartialType } from '@nestjs/swagger';
+import { FilterQuery, Model, Types } from 'mongoose';
+import { Pagination } from 'src/core/helpers/pagination.helper';
+import { CloudinaryService } from 'src/core/module/cloudinary/cloudinary.service';
+import { Tender } from 'src/models/tender.entity';
+
+class TenderParams {
+    title: string;
+    announcer: Types.ObjectId;
+    category: Types.ObjectId;
+    marketType: Types.ObjectId;
+    deadline: Date;
+    sources: {
+        images: Express.Multer.File[];
+        newsPaper: Types.ObjectId;
+    }[];
+    isStartup: boolean;
+
+}
+
+class OptionalTenderParams extends PartialType(TenderParams) { }
+
+@Injectable()
+export class TenderService {
+    constructor(
+        @InjectModel(Tender.name) private readonly tenderModel: Model<Tender>,
+        private readonly cloudinaryService: CloudinaryService,
+    ) { }
+
+    create = async (data: TenderParams) => {
+        const { title, announcer, category, marketType, deadline, sources, isStartup } = data;
+
+        const tender = new this.tenderModel({ title, announcer, category, marketType, deadline, isStartup });
+
+        const imageUrls = await Promise.all(sources.map(async source => {
+            const { images, newsPaper } = source;
+            const urls = await Promise.all(images.map(async image => {
+                const url = await this.cloudinaryService.uploadImage(image, {
+                    name: `${tender._id}-${newsPaper}-${images.indexOf(image)}`,
+                    folder: 'tender',
+                });
+                return url;
+            }));
+            return {
+                imageUrls: urls,
+                newsPaper
+            };
+        }));
+
+        tender.sources = imageUrls as any;
+
+        await tender.save();
+        return this.tenderModel.findById(tender._id).populate('announcer category marketType sources.newsPaper');
+
+    }
+
+    update = async (id: Types.ObjectId, data: OptionalTenderParams) => {
+        const { title, announcer, category, marketType, deadline, sources, isStartup } = data;
+
+        const tender = await this.tenderModel.findById(id);
+
+        if (title) tender.title = title;
+        if (announcer) tender.announcer._id = announcer;
+        if (category) tender.category._id = category;
+        if (marketType) tender.marketType._id = marketType;
+        if (deadline) tender.deadline = deadline;
+        if (isStartup !== undefined) tender.isStartup = isStartup;
+
+        if (sources) {
+            const imageUrls = await Promise.all(sources.map(async source => {
+                const { images, newsPaper } = source;
+                const urls = await Promise.all(images.map(async image => {
+                    const url = await this.cloudinaryService.uploadImage(image, {
+                        name: `${tender._id}-${newsPaper}-${images.indexOf(image)}`,
+                        folder: 'tender',
+                    });
+                    return url;
+                }));
+                return {
+                    imageUrls: urls,
+                    newsPaper
+                };
+            }));
+
+            tender.sources = imageUrls as any;
+        }
+
+        if (tender.isModified()) return await tender.save();
+    }
+
+    delete = async (id: Types.ObjectId) => {
+        await this.tenderModel.findByIdAndDelete(id);
+    }
+
+    findAll = async (
+        filters: {
+            category?: Types.ObjectId,
+            marketType?: Types.ObjectId,
+            announcer?: Types.ObjectId,
+            deadline?: Date
+            startup?: boolean
+        },
+        options: {
+            keyword?: string,
+            sort?: string
+            fields?: string,
+        },
+        pagination: {
+            page: number,
+            limit: number
+        }
+    ) => {
+        const { page, limit } = pagination;
+        const { category, marketType, announcer, deadline, startup } = filters;
+        const { keyword, fields, sort } = options;
+
+        const filter: FilterQuery<Tender> = {};
+
+        if (keyword) filter.title = { $regex: keyword, $options: 'i' };
+        if (category) filter.category = category;
+        if (marketType) filter.marketType = marketType;
+        if (announcer) filter.announcer = announcer;
+        if (deadline) filter.deadline = { $gte: deadline };
+        if (startup !== undefined) filter.isStartup = startup;
+
+        const { generate, skip } = new Pagination(this.tenderModel, { page, limit, filter }).getOptions();
+
+
+        return generate(
+            await this.tenderModel.find(filter)
+                .populate('announcer category marketType')
+                .sort(sort)
+                .select(fields || 'title announcer category marketType deadline isStartup')
+                .skip(skip)
+                .limit(limit)
+        )
+    }
+
+
+
+
+}


### PR DESCRIPTION
Introduce a new Tender module with full CRUD capabilities and integrate the isStartup flag into both Announcer and Tender entities. This enhancement allows for better categorization of tenders as startup-related.