### PR TITLE
Add Announcer and NewsPaper modules with CRUD operations

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -7,6 +7,8 @@ import { APP_FILTER, APP_INTERCEPTOR } from '@nestjs/core';
 import { ResponseInterceptor } from './core/interceptors/response.interceptor';
 import { HttpExceptionFilter } from './core/interceptors/http-exception.filter';
 import { UserModule } from './module/user/user.module';
+import { TenderModule } from './module/tender/tender.module';
+import { AnnouncerModule } from './module/announcer/announcer.module';
 
 
 
@@ -16,6 +18,8 @@ import { UserModule } from './module/user/user.module';
     JwtAuthModule.register(),
     AuthModule,
     UserModule,
+    TenderModule,
+    AnnouncerModule,
   ],
 
   providers: [

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -9,6 +9,7 @@ import { HttpExceptionFilter } from './core/interceptors/http-exception.filter';
 import { UserModule } from './module/user/user.module';
 import { TenderModule } from './module/tender/tender.module';
 import { AnnouncerModule } from './module/announcer/announcer.module';
+import { NewsPaperModule } from './module/news-paper/news-paper.module';
 
 
 
@@ -20,6 +21,7 @@ import { AnnouncerModule } from './module/announcer/announcer.module';
     UserModule,
     TenderModule,
     AnnouncerModule,
+    NewsPaperModule,
   ],
 
   providers: [

--- a/src/core/shared/args/pagination.arg.ts
+++ b/src/core/shared/args/pagination.arg.ts
@@ -5,7 +5,7 @@ export interface PaginationArg {
 
 }
 
-export interface FilterArg {
+export interface FilterArgs {
     keyword: string;
     fields: string;
     sort: string;

--- a/src/core/shared/dtos/id-param.dto.ts
+++ b/src/core/shared/dtos/id-param.dto.ts
@@ -1,4 +1,5 @@
 import { IsMongoId } from "class-validator";
+import { Types } from "mongoose";
 
 export class IdParams {
     /**
@@ -6,5 +7,5 @@ export class IdParams {
      * @example 1
      */
     @IsMongoId()
-    id: string;
+    id: Types.ObjectId;
 }

--- a/src/models/announcer.entity.ts
+++ b/src/models/announcer.entity.ts
@@ -1,0 +1,17 @@
+import { Schema as KScheam, Prop } from "@nestjs/mongoose";
+import { AbstractSchema } from "../core/models/abstract-schema";
+
+
+
+
+@KScheam({
+    timestamps: true,
+})
+export class Announcer extends AbstractSchema {
+    @Prop()
+    name: string;
+
+    @Prop()
+    imageUri: string;
+
+}

--- a/src/models/news-paper.ts
+++ b/src/models/news-paper.ts
@@ -1,20 +1,14 @@
 import { Schema as KScheam, Prop } from "@nestjs/mongoose";
 import { AbstractSchema } from "../core/models/abstract-schema";
 
-
-
-
 @KScheam({
     timestamps: true,
 })
-export class Announcer extends AbstractSchema {
+export class NewsPaper extends AbstractSchema {
     @Prop()
     name: string;
 
     @Prop()
     imageUri: string;
-
-    @Prop()
-    isStartup: boolean;
 
 }

--- a/src/models/tender.entity.ts
+++ b/src/models/tender.entity.ts
@@ -1,0 +1,51 @@
+import { Schema as KScheam, Prop } from "@nestjs/mongoose";
+import { AbstractSchema } from "../core/models/abstract-schema";
+import { Schema } from "mongoose";
+import { Announcer } from "./announcer.entity";
+import { NewsPaper } from "./news-paper";
+
+
+
+
+@KScheam({
+    timestamps: true,
+})
+export class Tender extends AbstractSchema {
+    @Prop()
+    title: string;
+
+    @Prop({ type: Schema.Types.ObjectId, ref: Announcer.name })
+    announcer: Announcer;
+
+    @Prop()
+    publishedDate: Date;
+
+    @Prop()
+    closingDate: Date;
+
+    @Prop()
+    chargePrice?: number;
+
+    @Prop()
+    marketType : string;
+
+    @Prop()
+    industry : string;
+
+    @Prop()
+    region : string;
+
+    @Prop({
+        type: [{
+            newsPaper: { type: Schema.Types.ObjectId, ref: NewsPaper.name },
+            images: [String]
+        }],
+        _id: false,
+    })
+    sources: {
+        newsPaper: NewsPaper,
+        images: string[],
+    }[]
+    tender: import("mongoose").Types.ObjectId;
+
+}

--- a/src/module/announcer/announcer.controller.ts
+++ b/src/module/announcer/announcer.controller.ts
@@ -1,0 +1,72 @@
+import { Body, Controller, Delete, Get, Param, Patch, Post, Query } from '@nestjs/common';
+import { AnnouncerService } from './announcer.service';
+import { Role } from '../auth/guards/auth.guard';
+import { UserRoles } from 'src/core/enums/user-roles.enum';
+import { ApiResult } from 'src/core/types/api-response';
+import { PaginationQuery } from 'src/core/shared/dtos/pagination.dto';
+import { IdParams } from 'src/core/shared/dtos/id-param.dto';
+import { CreateAnnouncerBody } from './dto/create-announcer.dto';
+import { UpdateAnnouncerBody } from './dto/update-annuoncer.dto';
+
+@Controller('announcer')
+@Role(UserRoles.ADMIN)
+export class AnnouncerController {
+  constructor(private readonly announcerService: AnnouncerService) { }
+
+
+  @Get()
+  async getAnnouncers(
+    @Query() query: PaginationQuery,
+  ): Promise<ApiResult> {
+    const { fields, keyword, limit, page, sort } = query;
+
+    return this.announcerService.getAnnouncers({ fields, keyword, sort }, { limit, page });
+  }
+
+  @Get(':id')
+  async getAnnouncer(
+    @Param() params: IdParams,
+  ): Promise<ApiResult> {
+    const { id } = params;
+
+    const announcer = this.announcerService.getAnnouncer(id);
+
+    return { data: announcer };
+  }
+
+  @Post()
+  async createAnnouncer(
+    @Body() body: CreateAnnouncerBody,
+  ): Promise<ApiResult> {
+    const { name, imageUri } = body;
+
+    const announcer = await this.announcerService.createAnnouncer({ name, imageUri });
+
+    return { data: announcer };
+  }
+
+  @Patch(':id')
+  async updateAnnouncer(
+    @Param() params: IdParams,
+    @Body() body: UpdateAnnouncerBody,
+  ): Promise<ApiResult> {
+    const { id } = params;
+    const { name, imageUri } = body;
+
+    const announcer = await this.announcerService.updateAnnouncer({ id, name, imageUri });
+
+    return { data: announcer };
+  }
+
+  @Delete(':id')
+  async deleteAnnouncer(
+    @Param() params: IdParams,
+  ): Promise<ApiResult> {
+    const { id } = params;
+
+    const announcer = await this.announcerService.deleteAnnouncer(id);
+
+    return { data: announcer };
+  }
+
+}

--- a/src/module/announcer/announcer.controller.ts
+++ b/src/module/announcer/announcer.controller.ts
@@ -38,9 +38,9 @@ export class AnnouncerController {
   async createAnnouncer(
     @Body() body: CreateAnnouncerBody,
   ): Promise<ApiResult> {
-    const { name, imageUri } = body;
+    const { name, imageUri, isStartup } = body;
 
-    const announcer = await this.announcerService.createAnnouncer({ name, imageUri });
+    const announcer = await this.announcerService.createAnnouncer({ name, imageUri, isStartup });
 
     return { data: announcer };
   }
@@ -51,9 +51,9 @@ export class AnnouncerController {
     @Body() body: UpdateAnnouncerBody,
   ): Promise<ApiResult> {
     const { id } = params;
-    const { name, imageUri } = body;
+    const { name, imageUri, isStartup } = body;
 
-    const announcer = await this.announcerService.updateAnnouncer({ id, name, imageUri });
+    const announcer = await this.announcerService.updateAnnouncer({ id, name, imageUri, isStartup });
 
     return { data: announcer };
   }

--- a/src/module/announcer/announcer.module.ts
+++ b/src/module/announcer/announcer.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { AnnouncerService } from './announcer.service';
+import { AnnouncerController } from './announcer.controller';
+import { DatabaseModule } from 'src/core/module/database.module';
+import { Announcer } from 'src/models/announcer.entity';
+
+@Module({
+  imports: [
+    DatabaseModule.forFeature([Announcer]),
+  ],
+  controllers: [AnnouncerController],
+  providers: [AnnouncerService],
+})
+export class AnnouncerModule { }

--- a/src/module/announcer/announcer.service.ts
+++ b/src/module/announcer/announcer.service.ts
@@ -5,7 +5,7 @@ import { MongoRepository } from 'src/core/helpers/mongo.helper';
 import { Announcer } from 'src/models/announcer.entity';
 import { CreateAnnouncerArgs } from './args/create-announcer.args';
 import { UpdateAnnouncerArgs } from './args/update-announcer.args';
-import { FilterArg, PaginationArg } from 'src/core/shared/args/pagination.arg';
+import { FilterArgs, PaginationArg } from 'src/core/shared/args/pagination.arg';
 
 @Injectable()
 export class AnnouncerService {
@@ -28,7 +28,7 @@ export class AnnouncerService {
     }
 
     async getAnnouncers(
-        filters: FilterArg,
+        filters: FilterArgs,
         paginationArg?: PaginationArg,
     ) {
         const { keyword, fields, sort } = filters || {};

--- a/src/module/announcer/announcer.service.ts
+++ b/src/module/announcer/announcer.service.ts
@@ -1,0 +1,52 @@
+import { Injectable } from '@nestjs/common';
+import { InjectModel } from '@nestjs/mongoose';
+import { Model, Types } from 'mongoose';
+import { MongoRepository } from 'src/core/helpers/mongo.helper';
+import { Announcer } from 'src/models/announcer.entity';
+import { CreateAnnouncerArgs } from './args/create-announcer.args';
+import { UpdateAnnouncerArgs } from './args/update-announcer.args';
+import { FilterArg, PaginationArg } from 'src/core/shared/args/pagination.arg';
+
+@Injectable()
+export class AnnouncerService {
+    announcerRepo: MongoRepository<Announcer>;
+
+    constructor(
+        @InjectModel(Announcer.name) private readonly announcerModel: Model<Announcer>,
+    ) {
+        this.announcerRepo = new MongoRepository<Announcer>(this.announcerModel);
+    }
+
+    async createAnnouncer(args: CreateAnnouncerArgs) {
+        return this.announcerRepo.create(args);
+    }
+
+
+    async updateAnnouncer(args: UpdateAnnouncerArgs) {
+        const { id, ...rest } = args;
+        return this.announcerRepo.updateOne({ _id: id }, rest);
+    }
+
+    async getAnnouncers(
+        filters: FilterArg,
+        paginationArg?: PaginationArg,
+    ) {
+        const { keyword, fields, sort } = filters || {};
+
+        return this.announcerRepo.findWithPagination({
+            filter: { name: { $regex: keyword, $options: 'i' } },
+            options: { sort: { [sort || 'createdAt']: -1 }, fields },
+        }, paginationArg);
+    }
+
+    async getAnnouncer(id: Types.ObjectId) {
+        return this.announcerRepo.findOne({ _id: id });
+    }
+
+    async deleteAnnouncer(id: Types.ObjectId) {
+        return this.announcerRepo.deleteOne({ _id: id });
+    }
+
+
+
+}

--- a/src/module/announcer/args/create-announcer.args.ts
+++ b/src/module/announcer/args/create-announcer.args.ts
@@ -1,0 +1,4 @@
+export interface CreateAnnouncerArgs {
+    name: string;
+    imageUri: string;
+}

--- a/src/module/announcer/args/create-announcer.args.ts
+++ b/src/module/announcer/args/create-announcer.args.ts
@@ -1,4 +1,5 @@
 export interface CreateAnnouncerArgs {
     name: string;
     imageUri: string;
+    isStartup: boolean;
 }

--- a/src/module/announcer/args/update-announcer.args.ts
+++ b/src/module/announcer/args/update-announcer.args.ts
@@ -1,0 +1,4 @@
+import { CreateAnnouncerArgs } from "./create-announcer.args";
+import { IdArg } from "src/core/shared/args/id.arg";
+
+export interface UpdateAnnouncerArgs extends Partial<CreateAnnouncerArgs>, IdArg { }

--- a/src/module/announcer/dto/create-announcer.dto.ts
+++ b/src/module/announcer/dto/create-announcer.dto.ts
@@ -1,0 +1,19 @@
+import { IsString, IsUrl } from "class-validator";
+
+export class CreateAnnouncerBody {
+    /**
+     * Name of the announcer
+     * @example John Doe
+     */
+    @IsString()
+    name: string;
+
+    /**
+     * Image URL of the announcer
+     * @example https://example.com/image.jpg
+     */
+    @IsUrl()
+    imageUri: string;
+    
+
+}

--- a/src/module/announcer/dto/update-annuoncer.dto.ts
+++ b/src/module/announcer/dto/update-annuoncer.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from "@nestjs/swagger";
+import { CreateAnnouncerBody } from "./create-announcer.dto";
+
+export class UpdateAnnouncerBody extends PartialType(CreateAnnouncerBody) { }

--- a/src/module/auth/auth.controller.ts
+++ b/src/module/auth/auth.controller.ts
@@ -17,7 +17,7 @@ export class AuthController {
   constructor(private readonly authService: AuthService) { }
 
 
-  @Post('login')
+  @Post('login') //* AUTH | Login ~ {{host}}/auth/login
   async login(
     @Body() body: LoginBodyDto
   ): Promise<ApiResult> {

--- a/src/module/news-paper/args/create-npaper.args.ts
+++ b/src/module/news-paper/args/create-npaper.args.ts
@@ -1,0 +1,4 @@
+export interface CreateNewsPaperArgs {
+    name: string;
+    imageUri: string;
+}

--- a/src/module/news-paper/args/update-npaper.args.ts
+++ b/src/module/news-paper/args/update-npaper.args.ts
@@ -1,0 +1,4 @@
+import { CreateNewsPaperArgs } from "./create-npaper.args";
+import { IdArg } from "src/core/shared/args/id.arg";
+
+export interface UpdateNewsPaperArgs extends Partial<CreateNewsPaperArgs>, IdArg { }

--- a/src/module/news-paper/dto/create-npaper.dto.ts
+++ b/src/module/news-paper/dto/create-npaper.dto.ts
@@ -1,6 +1,6 @@
 import { IsString, IsUrl } from "class-validator";
 
-export class CreateAnnouncerBody {
+export class CreateNewsPaperBody {
     /**
      * Name of the announcer
      * @example John Doe
@@ -14,12 +14,6 @@ export class CreateAnnouncerBody {
      */
     @IsUrl()
     imageUri: string;
-
-    /**
-     * Is the announcer a startup?
-     * @example true
-     */
-    isStartup: boolean;
     
 
 }

--- a/src/module/news-paper/dto/update-npaper.dto.ts
+++ b/src/module/news-paper/dto/update-npaper.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from "@nestjs/swagger";
+import { CreateNewsPaperBody } from "./create-npaper.dto";
+
+export class UpdateNewsPaperBody extends PartialType(CreateNewsPaperBody) { }

--- a/src/module/news-paper/news-paper.controller.ts
+++ b/src/module/news-paper/news-paper.controller.ts
@@ -1,0 +1,70 @@
+import { Body, Controller, Delete, Get, Param, Patch, Post, Query } from '@nestjs/common';
+import { NewsPaperService } from './news-paper.service';
+import { IdParams } from 'src/core/shared/dtos/id-param.dto';
+import { PaginationQuery } from 'src/core/shared/dtos/pagination.dto';
+import { ApiResult } from 'src/core/types/api-response';
+import { CreateNewsPaperBody } from './dto/create-npaper.dto';
+import { UpdateNewsPaperBody } from './dto/update-npaper.dto';
+
+@Controller('news-paper')
+export class NewsPaperController {
+  constructor(private readonly newsPaperService: NewsPaperService) {}
+
+
+  
+    @Get()
+    async getNewsPapers(
+      @Query() query: PaginationQuery,
+    ): Promise<ApiResult> {
+      const { fields, keyword, limit, page, sort } = query;
+  
+      return this.newsPaperService.getNewsPapers({ fields, keyword, sort }, { limit, page });
+    }
+  
+    @Get(':id')
+    async getNewsPaper(
+      @Param() params: IdParams,
+    ): Promise<ApiResult> {
+      const { id } = params;
+  
+      const newsPaper = this.newsPaperService.getNewsPaper(id);
+  
+      return { data: newsPaper };
+    }
+  
+    @Post()
+    async createNewsPaper(
+      @Body() body: CreateNewsPaperBody,
+    ): Promise<ApiResult> {
+      const { name, imageUri } = body;
+  
+      const newsPaper = await this.newsPaperService.createNewsPaper({ name, imageUri });
+  
+      return { data: newsPaper };
+    }
+  
+    @Patch(':id')
+    async updateNewsPaper(
+      @Param() params: IdParams,
+      @Body() body: UpdateNewsPaperBody,
+    ): Promise<ApiResult> {
+      const { id } = params;
+      const { name, imageUri } = body;
+  
+      const newsPaper = await this.newsPaperService.updateNewsPaper({ id, name, imageUri });
+  
+      return { data: newsPaper };
+    }
+  
+    @Delete(':id')
+    async deleteNewsPaper(
+      @Param() params: IdParams,
+    ): Promise<ApiResult> {
+      const { id } = params;
+  
+      const newsPaper = await this.newsPaperService.deleteNewsPaper(id);
+  
+      return { data: newsPaper };
+    }
+  
+}

--- a/src/module/news-paper/news-paper.module.ts
+++ b/src/module/news-paper/news-paper.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { NewsPaperService } from './news-paper.service';
+import { NewsPaperController } from './news-paper.controller';
+import { NewsPaper } from 'src/models/news-paper';
+import { DatabaseModule } from 'src/core/module/database.module';
+
+@Module({
+  imports: [
+    DatabaseModule.forFeature([NewsPaper]),
+  ],
+  controllers: [NewsPaperController],
+  providers: [NewsPaperService],
+})
+export class NewsPaperModule {}

--- a/src/module/news-paper/news-paper.service.ts
+++ b/src/module/news-paper/news-paper.service.ts
@@ -1,0 +1,52 @@
+import { Injectable } from '@nestjs/common';
+import { InjectModel } from '@nestjs/mongoose';
+import { Model, Types } from 'mongoose';
+import { MongoRepository } from 'src/core/helpers/mongo.helper';
+import { FilterArgs, PaginationArg } from 'src/core/shared/args/pagination.arg';
+import { NewsPaper } from 'src/models/news-paper';
+import { CreateNewsPaperArgs } from './args/create-npaper.args';
+import { UpdateNewsPaperArgs } from './args/update-npaper.args';
+
+@Injectable()
+export class NewsPaperService {
+    newsPaperRepo: MongoRepository<NewsPaper>;
+
+    constructor(
+        @InjectModel(NewsPaper.name) private readonly newsPaperModel: Model<NewsPaper>,
+    ) {
+        this.newsPaperRepo = new MongoRepository<NewsPaper>(this.newsPaperModel);
+    }
+
+    async createNewsPaper(args: CreateNewsPaperArgs) {
+        return this.newsPaperRepo.create(args);
+    }
+
+
+    async updateNewsPaper(args: UpdateNewsPaperArgs) {
+        const { id, ...rest } = args;
+        return this.newsPaperRepo.updateOne({ _id: id }, rest);
+    }
+
+    async getNewsPapers(
+        filters: FilterArgs,
+        paginationArg?: PaginationArg,
+    ) {
+        const { keyword, fields, sort } = filters || {};
+
+        return this.newsPaperRepo.findWithPagination({
+            filter: { name: { $regex: keyword, $options: 'i' } },
+            options: { sort: { [sort || 'createdAt']: -1 }, fields },
+        }, paginationArg);
+    }
+
+    async getNewsPaper(id: Types.ObjectId) {
+        return this.newsPaperRepo.findOne({ _id: id });
+    }
+
+    async deleteNewsPaper(id: Types.ObjectId) {
+        return this.newsPaperRepo.deleteOne({ _id: id });
+    }
+
+
+
+}

--- a/src/module/tender/args/tender-details.ts
+++ b/src/module/tender/args/tender-details.ts
@@ -1,0 +1,24 @@
+import { Types } from "mongoose";
+
+export interface CreateTenderArg {
+    title: string;
+    announcer: Types.ObjectId;
+    publishedDate: Date;
+    closingDate: Date;
+    chargePrice?: number;
+    marketType: string;
+    industry: string;
+    region: string;
+    sources: {
+        newsPaper: Types.ObjectId;
+        images: string[];
+    }[]
+}
+
+export interface UpdateTenderArg extends Partial<Omit<CreateTenderArg, 'sources'>> {
+    sources?: {
+        newsPaper: Types.ObjectId;
+        imagesToAdd?: string[];
+        imagesToRemove?: string[];
+    }[]
+}

--- a/src/module/tender/args/tender-filter.args.ts
+++ b/src/module/tender/args/tender-filter.args.ts
@@ -1,0 +1,11 @@
+import { Types } from "mongoose";
+
+export interface TenderFilterArgs {
+    announcer?: Types.ObjectId;
+    publishedAfter?: Date;
+    closingBefore?: Date;
+    marketType?: string;
+    industries?: string[];
+    isStartup?: boolean;
+    regions?: string[];
+}

--- a/src/module/tender/dto/create-tender.dto.ts
+++ b/src/module/tender/dto/create-tender.dto.ts
@@ -1,0 +1,90 @@
+import { Type } from "class-transformer";
+import { IsDate, IsMongoId, IsNumber, IsOptional, IsString, IsUrl, MinLength, ValidateNested } from "class-validator";
+import { Types } from "mongoose";
+
+class SourceDTO {
+    /**
+     * The news paper id
+     * @example 'News paper id'
+     */
+    @IsMongoId()
+    newsPaper: Types.ObjectId;
+
+    /**
+     * The images of the news paper
+     * @example ['image1', 'image2']
+     */
+    @IsUrl({}, { each: true })
+    images: string[];
+}
+
+
+export class CreateTenderBody {
+
+    /**
+     * The title of the tender
+     * @example 'Tender title'
+     */
+    @IsString()
+    @MinLength(5)
+    title: string;
+
+    /**
+     * The announcer of the tender
+     * @example 'Announcer id'
+     */
+    @IsMongoId()
+    announcer: Types.ObjectId;
+
+    /**
+     * The published date of the tender
+     * @example '2021-01-01T00:00:00.000Z'
+     */
+    @IsDate()
+    publishedDate: Date;
+
+    /**
+     * The closing date of the tender
+     * @example '2021-01-01T00:00:00.000Z'
+     */
+    @IsDate()
+    closingDate: Date;
+
+    /**
+     * The charge price of the tender
+     * @example 100
+     */
+    @IsOptional()
+    @IsNumber()
+    chargePrice?: number;
+
+    /**
+     * The market type of the tender
+     * @example 'Market type'
+     */
+    @IsString()
+    marketType: string;
+
+    /**
+     * The industry of the tender
+     * @example 'Industry'
+     */
+    @IsString()
+    industry: string;
+
+    /**
+     * The region of the tender
+     * @example 'Region'
+     */
+    @IsString()
+    region: string;
+
+    /**
+     * The sources of the tender
+     * @example 'Sources'
+     */
+    @ValidateNested({ each: true })
+    @Type(() => SourceDTO)
+    sources: SourceDTO[];
+
+}

--- a/src/module/tender/dto/tender-filter.dto.ts
+++ b/src/module/tender/dto/tender-filter.dto.ts
@@ -1,0 +1,63 @@
+import { IsBoolean, IsDate, IsMongoId, IsOptional, IsString } from "class-validator";
+import { Types } from "mongoose";
+import { PaginationQuery } from "src/core/shared/dtos/pagination.dto";
+
+export class TenderFilterQuery extends PaginationQuery {
+    /**
+     * filter by announcer
+     * @example 'AnnouncerId'
+     */
+    @IsOptional()
+    @IsMongoId()
+    announcer?: Types.ObjectId;
+
+    /**
+     * filter by published date after
+     * @example '2021-09-01 00:00:00'
+     */
+    @IsOptional()
+    @IsDate()
+    publishedAfter?: Date;
+
+    /**
+     * filter by closing date before
+     * @example '2021-09-01 00:00:00'
+     */
+    @IsOptional()
+    @IsDate()
+    closingBefore?: Date;
+
+    /**
+     * filter by market type
+     * @example 'marketType'
+     */
+    @IsOptional()
+    @IsString()
+    marketType?: string;
+
+    /**
+     * filter by industries
+     * @example ['industry1', 'industry2']
+     */
+    @IsOptional()
+    @IsString({ each: true })
+    industries?: string[];
+
+    /**
+     * filter by startup
+     * @example true
+     */
+    @IsOptional()
+    @IsBoolean()
+    isStartup?: boolean;
+
+    /**
+     * filter by regions
+     * @example ['region1', 'region2']
+     */
+    @IsOptional()
+    @IsString({ each: true })
+    regions?: string[];
+
+}
+

--- a/src/module/tender/dto/update-tender.dto.ts
+++ b/src/module/tender/dto/update-tender.dto.ts
@@ -1,0 +1,38 @@
+import { OmitType, PartialType } from "@nestjs/swagger";
+import { CreateTenderBody } from "./create-tender.dto";
+import { IsMongoId, IsOptional, IsUrl, ValidateNested } from "class-validator";
+import { Types } from "mongoose";
+import { Type } from "class-transformer";
+
+class SourceDTO {
+    /**
+     * The news paper id
+     * @example 'News paper id'
+     */
+    @IsMongoId()
+    newsPaper: Types.ObjectId;
+
+    /**
+     * The images to add to the news paper
+     * @example ['image1', 'image2']
+     */
+    @IsOptional()
+    @IsUrl({}, { each: true })
+    imagesToAdd?: string[];
+
+    /**
+     * The images to remove from the news paper
+     * @example ['image1', 'image2']
+     */
+    @IsOptional()
+    @IsUrl({}, { each: true })
+    imagesToRemove?: string[];
+}
+
+export class UpdateTenderBody extends PartialType(OmitType(CreateTenderBody, ['sources'] as const)) {
+
+    @ValidateNested({ each: true })
+    @Type(() => SourceDTO)
+    sources?: SourceDTO[];
+
+}

--- a/src/module/tender/tender.controller.ts
+++ b/src/module/tender/tender.controller.ts
@@ -1,0 +1,59 @@
+import { Body, Controller, Delete, Get, Param, Patch, Post, Query } from '@nestjs/common';
+import { TenderService } from './tender.service';
+import { TenderFilterQuery } from './dto/tender-filter.dto';
+import { query } from 'express';
+import { IdParams } from 'src/core/shared/dtos/id-param.dto';
+import { ApiResult } from 'src/core/types/api-response';
+import { CreateTenderBody } from './dto/create-tender.dto';
+import { UpdateTenderBody } from './dto/update-tender.dto';
+
+@Controller('tender')
+export class TenderController {
+  constructor(private readonly tenderService: TenderService) { }
+
+  @Get()
+  async getTenders(
+    @Query() query: TenderFilterQuery,
+  ): Promise<ApiResult<any>> {
+    const { page, limit, sort, keyword, fields, ...filterArgs } = query
+
+    const { pagination, data } = await this.tenderService.findAll(filterArgs, { sort, fields, keyword }, { page, limit })
+
+    return { pagination, data }
+  }
+
+  @Get(':id')
+  async getTender(
+    @Param() params: IdParams,
+  ) {
+    const tender = await this.tenderService.findOne(params.id)
+    return { data: tender }
+  }
+
+  @Post()
+  async createTender(
+    @Body() data: CreateTenderBody,
+  ) {
+    const tender = await this.tenderService.create(data)
+    return { data: tender }
+  }
+
+  @Patch(':id')
+  async updateTender(
+    @Param() params: IdParams,
+    @Body() data: UpdateTenderBody,
+  ) {
+    const tender = await this.tenderService.updateOne(params.id, data)
+    return { data: tender }
+  }
+
+  @Delete(':id')
+  async deleteTender(
+    @Param() params: IdParams,
+  ) {
+    const tender = await this.tenderService.deleteOne(params.id)
+    return { data: tender }
+  }
+
+
+}

--- a/src/module/tender/tender.module.ts
+++ b/src/module/tender/tender.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { TenderService } from './tender.service';
+import { TenderController } from './tender.controller';
+import { DatabaseModule } from 'src/core/module/database.module';
+import { Tender } from 'src/models/tender.entity';
+
+@Module({
+  imports: [
+    DatabaseModule.forFeature([Tender]),
+  ],
+  controllers: [TenderController],
+  providers: [TenderService],
+})
+export class TenderModule { }

--- a/src/module/tender/tender.service.ts
+++ b/src/module/tender/tender.service.ts
@@ -1,0 +1,128 @@
+import { Injectable } from '@nestjs/common';
+import { InjectModel } from '@nestjs/mongoose';
+import { Model, Types } from 'mongoose';
+import { MongoRepository } from 'src/core/helpers/mongo.helper';
+import { Tender } from 'src/models/tender.entity';
+import { TenderFilterArgs } from './args/tender-filter.args';
+import { FilterArgs, PaginationArg } from 'src/core/shared/args/pagination.arg';
+import { title } from 'process';
+import { CreateTenderArg, UpdateTenderArg } from './args/tender-details';
+
+@Injectable()
+export class TenderService {
+    private readonly tnderRepository: MongoRepository<Tender, CreateTenderArg>;
+    constructor(
+        @InjectModel(Tender.name) private readonly tenderModel: Model<Tender>,
+    ) {
+        this.tnderRepository = new MongoRepository(tenderModel);
+    }
+
+    async findAll(
+        tenderFilter: TenderFilterArgs,
+        filters: FilterArgs,
+        pagination: PaginationArg,
+    ) {
+        const { keyword, fields, sort } = filters;
+        const { announcer, closingBefore, industries, isStartup, marketType, publishedAfter, regions } = tenderFilter;
+        return this.tnderRepository.aggregateWithPagination(
+            [
+                {
+                    $lookup: {
+                        from: 'announcers',
+                        localField: 'announcer',
+                        foreignField: '_id',
+                        as: 'announcer',
+                    },
+                },
+                {
+                    $match: {
+                        $and: [
+                            title ? { title: { $regex: keyword, $options: 'i' } } : {},
+                            announcer ? { 'announcer._id': announcer } : {},
+                            publishedAfter ? { publishedAt: { $gte: publishedAfter } } : {},
+                            closingBefore ? { closingAt: { $lte: closingBefore } } : {},
+                            marketType ? { marketType } : {},
+                            industries ? { industries: { $in: industries } } : {},
+                            isStartup ? { 'announcer.isStartup': isStartup } : {},
+                            regions ? { regions: { $in: regions } } : {},
+                        ],
+                    },
+                },
+                {
+                    $sort: { [sort || 'publishedAt']: -1 },
+                },
+                {
+
+                    $project: {
+                        title: fields ? fields.includes('title') ? 1 : 0 : 1,
+                        announcer: fields ? fields.includes('announcer') ? 1 : 0 : 1,
+                        publishedDate: fields ? fields.includes('publishedDate') ? 1 : 0 : 1,
+                        closingDate: fields ? fields.includes('closingDate') ? 1 : 0 : 1,
+                        chargePrice: fields ? fields.includes('chargePrice') ? 1 : 0 : 1,
+                        marketType: fields ? fields.includes('marketType') ? 1 : 0 : 1,
+                        industry: fields ? fields.includes('industry') ? 1 : 0 : 1,
+                        region: fields ? fields.includes('region') ? 1 : 0 : 1,
+                        // sources: fields ? fields.includes('sources') ? 1 : 0 : 1,
+                    },
+
+                },
+            ],
+            pagination,
+        );
+
+    }
+
+    async create(data: CreateTenderArg) {
+        return this.tnderRepository.create(data);
+    }
+
+    async findOne(id: Types.ObjectId) {
+        return this.tnderRepository.findOne({ _id: id }); //TODO aggregate to add isFollowed field
+    }
+
+    async updateOne(id: Types.ObjectId, data: UpdateTenderArg) {
+        const { sources, announcer, chargePrice, closingDate, industry, marketType, publishedDate, region, title } = data;
+
+        const tender = await this.tnderRepository.findOne({ _id: id });
+
+        if (announcer) tender.announcer = announcer as any;
+        if (chargePrice) tender.chargePrice = chargePrice;
+        if (closingDate) tender.closingDate = closingDate;
+        if (industry) tender.industry = industry;
+        if (marketType) tender.marketType = marketType;
+        if (publishedDate) tender.publishedDate = publishedDate;
+        if (region) tender.region = region;
+        if (title) tender.title = title;
+        if (sources) {
+            sources.forEach(source => {
+                const index = tender.sources.findIndex(s => source.newsPaper.equals(s.newsPaper._id));
+                if (index === -1 && source.imagesToAdd && source.imagesToAdd.length > 0) {
+                    tender.sources.push({
+                        newsPaper: source.newsPaper as any,
+                        images: source.imagesToAdd,
+                    })
+                } else {
+                    const { imagesToAdd, imagesToRemove } = source;
+                    if (imagesToAdd) tender.sources[index].images.push(...imagesToAdd);
+                    if (imagesToRemove) {
+                        tender.sources[index].images = tender.sources[index].images.filter(i => !imagesToRemove.includes(i));
+
+                        // Remove the source if it has no images
+                        if (tender.sources[index].images.length === 0) tender.sources.splice(index, 1);
+                    }
+                }
+            });
+
+            tender.markModified('sources');
+        }
+
+        if (tender.isModified()) await tender.save();
+        return await tender.populate(['announcer', 'sources.newsPaper']);
+
+    }
+
+    async deleteOne(id: Types.ObjectId) {
+        return this.tnderRepository.deleteOne({ _id: id });
+    }
+
+}

--- a/src/module/user/user.service.ts
+++ b/src/module/user/user.service.ts
@@ -3,7 +3,7 @@ import { InjectModel } from '@nestjs/mongoose';
 import { FilterQuery, Model, Types } from 'mongoose';
 import { CryptHelper } from 'src/core/helpers/crypt.helper';
 import { MongoRepository } from 'src/core/helpers/mongo.helper';
-import { FilterArg, PaginationArg } from 'src/core/shared/args/pagination.arg';
+import { FilterArgs, PaginationArg } from 'src/core/shared/args/pagination.arg';
 import { User } from 'src/models/user.entity';
 
 @Injectable()
@@ -16,7 +16,7 @@ export class UserService {
     }
 
     findAll = async (
-        filters: FilterArg,
+        filters: FilterArgs,
         paginationArg?: PaginationArg,
 
     ) => {


### PR DESCRIPTION
Introduce Announcer and NewsPaper modules, implementing CRUD operations and enhancing related entities and DTOs. Update existing services and controllers to integrate these new modules.