### PR TITLE
Add TenderResult entity and module with CRUD operations

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -10,6 +10,7 @@ import { UserModule } from './module/user/user.module';
 import { TenderModule } from './module/tender/tender.module';
 import { AnnouncerModule } from './module/announcer/announcer.module';
 import { NewsPaperModule } from './module/news-paper/news-paper.module';
+import { TenderResultModule } from './module/tender-result/tender-result.module';
 
 
 
@@ -22,6 +23,7 @@ import { NewsPaperModule } from './module/news-paper/news-paper.module';
     TenderModule,
     AnnouncerModule,
     NewsPaperModule,
+    TenderResultModule,
   ],
 
   providers: [

--- a/src/models/tender-result.entity.ts
+++ b/src/models/tender-result.entity.ts
@@ -1,8 +1,8 @@
 import { Schema as KScheam, Prop } from "@nestjs/mongoose";
 import { AbstractSchema } from "../core/models/abstract-schema";
 import { Schema } from "mongoose";
-import { Announcer } from "./announcer.entity";
 import { NewsPaper } from "./news-paper";
+import { Tender } from "./tender.entity";
 
 
 
@@ -10,30 +10,21 @@ import { NewsPaper } from "./news-paper";
 @KScheam({
     timestamps: true,
 })
-export class Tender extends AbstractSchema {
+export class TenderResult extends AbstractSchema {
     @Prop()
     title: string;
-
-    @Prop({ type: Schema.Types.ObjectId, ref: Announcer.name })
-    announcer: Announcer;
 
     @Prop()
     publishedDate: Date;
 
     @Prop()
-    closingDate: Date;
-
-    @Prop()
-    chargePrice?: number;
-
-    @Prop()
-    marketType : string;
-
-    @Prop()
-    industry : string;
+    type : string;
 
     @Prop()
     region : string;
+
+    @Prop({ type: Schema.Types.ObjectId, ref: Tender.name })
+    tender: Tender;
 
     @Prop({
         type: [{

--- a/src/module/tender-result/args/result-details.args.ts
+++ b/src/module/tender-result/args/result-details.args.ts
@@ -1,0 +1,21 @@
+import { Types } from "mongoose";
+
+export interface CreateResultArgs {
+    title: string;
+    publishedDate: Date;
+    type: string;
+    tender: Types.ObjectId;
+    region: string;
+    sources: {
+        newsPaper: Types.ObjectId;
+        images: string[];
+    }[]
+}
+
+export interface UpdateResultArgs extends Partial<Omit<CreateResultArgs, 'sources'>> {
+    sources?: {
+        newsPaper: Types.ObjectId;
+        imagesToAdd?: string[];
+        imagesToRemove?: string[];
+    }[]
+}

--- a/src/module/tender-result/args/result-filter.args.ts
+++ b/src/module/tender-result/args/result-filter.args.ts
@@ -1,0 +1,8 @@
+import { Types } from "mongoose";
+
+export interface TenderResultFilterArgs {
+    publishedAfter?: Date;
+    region?: string;
+    type?: string;
+    tender?: Types.ObjectId;
+}

--- a/src/module/tender-result/dto/create-result.dto.ts
+++ b/src/module/tender-result/dto/create-result.dto.ts
@@ -1,0 +1,68 @@
+import { Type } from "class-transformer";
+import { IsArray, IsDate, IsMongoId, IsString, IsUrl, ValidateNested } from "class-validator";
+import { Types } from "mongoose";
+
+
+class SourceDTO {
+    /**
+     * news paper
+     * @example 'newsPaperId'
+     */
+    @IsMongoId()
+    newsPaper: Types.ObjectId;
+
+    /**
+     * images 
+     * @example ['imageURL']
+     */
+    @IsArray()
+    @IsUrl({}, { each: true })
+    images: string[];
+}
+
+export class CreateResultBody {
+    /**
+     * published date
+     * @example '2021-09-01 00:00:00'
+     */
+    @IsDate()
+    publishedDate: Date;
+
+    /**
+     * region
+     * @example 'region'
+     */
+    @IsString()
+    region: string;
+
+    /**
+     * tender
+     * @example 'tenderId'
+     */
+    @IsMongoId()
+    tender: Types.ObjectId;
+
+    /**
+     * type
+     * @example 'type'
+     */
+    @IsString()
+    type: string;
+
+    /**
+     * title
+     * @example 'title'
+     */
+    @IsString()
+    title: string;
+
+    /**
+     * sources
+     * @example [{ newsPaper: 'newsPaperId', images: ['imageId'] }]
+     */
+    @IsArray()
+    @ValidateNested({ each: true })
+    @Type(() => SourceDTO)
+    sources: SourceDTO[];
+
+}

--- a/src/module/tender-result/dto/tender-result-filter.dto.ts
+++ b/src/module/tender-result/dto/tender-result-filter.dto.ts
@@ -1,0 +1,40 @@
+import { IsDate, IsMongoId, IsOptional, IsString } from "class-validator";
+import { Types } from "mongoose";
+import { PaginationQuery } from "src/core/shared/dtos/pagination.dto";
+
+
+export class TenderResultFilterQuery extends PaginationQuery {
+    /**
+     * filter by published date after
+     * @example '2021-09-01 00:00:00'
+     */
+    @IsOptional()
+    @IsDate()
+    publishedAfter?: Date;
+
+    /**
+     * filter by region
+     * @example 'region'
+     */
+    @IsOptional()
+    @IsString()
+    region?: string;
+
+    /**
+     * filter by tender
+     * @example 'tenderId'
+     */
+    @IsOptional()
+    @IsMongoId()
+    tender?: Types.ObjectId;
+
+    /**
+     * filter by type
+     * @example 'type'
+     */
+    @IsOptional()
+    @IsString()
+    type?: string;
+
+
+}

--- a/src/module/tender-result/dto/update-result.dto.ts
+++ b/src/module/tender-result/dto/update-result.dto.ts
@@ -1,0 +1,45 @@
+import { OmitType, PartialType } from "@nestjs/swagger";
+import { IsArray, IsMongoId, IsOptional, IsUrl, ValidateNested } from "class-validator";
+import { CreateResultBody } from "./create-result.dto";
+import { Type } from "class-transformer";
+import { Types } from "mongoose";
+
+
+class SourceDTO {
+    /**
+     * news paper
+     * @example 'newsPaperId'
+     */
+    @IsMongoId()
+    newsPaper: Types.ObjectId;
+
+    /**
+     * images  to be added
+     * @example ['imageURL']
+     */
+    @IsOptional()
+    @IsArray()
+    @IsUrl({}, { each: true })
+    imagesToAdd?: string[];
+
+    /**
+     * images to be removed
+     * @example ['imageURL']
+     */
+    @IsOptional()
+    @IsArray()
+    @IsUrl({}, { each: true })
+    imagesToRemove?: string[];
+}
+
+export class UpdateResultBody extends PartialType(OmitType(CreateResultBody, ['sources'] as const)) {
+    /**
+     * sources
+     * @example [{ newsPaper: 'newsPaperId', imagesToAdd: ['imageId'], imagesToRemove: ['imageId'] }]
+     */
+    @IsOptional()
+    @ValidateNested({ each: true })
+    @Type(() => SourceDTO)
+    sources?: SourceDTO[];
+
+}

--- a/src/module/tender-result/tender-result.controller.ts
+++ b/src/module/tender-result/tender-result.controller.ts
@@ -1,0 +1,61 @@
+import { Body, Controller, Delete, Get, Param, Patch, Post, Query } from '@nestjs/common';
+import { TenderResultService } from './tender-result.service';
+import { TenderResultFilterQuery } from './dto/tender-result-filter.dto';
+import { ApiResult } from 'src/core/types/api-response';
+import { IdParams } from 'src/core/shared/dtos/id-param.dto';
+import { CreateResultBody } from './dto/create-result.dto';
+import { UpdateResultBody } from './dto/update-result.dto';
+
+@Controller('tender-result')
+export class TenderResultController {
+  constructor(private readonly tenderResultService: TenderResultService) { }
+
+  @Get()
+  async getAll(
+    @Query() filters: TenderResultFilterQuery,
+  ): Promise<ApiResult> {
+    const { fields, keyword, limit, page, sort, ...resultFilters } = filters;
+
+    const { data, pagination } = await this.tenderResultService.getAll(resultFilters, { fields, keyword, sort }, { limit, page })
+
+    return { data, pagination }
+  }
+
+  @Get(':id')
+  async getOne(
+    @Param() params: IdParams,
+  ) {
+    const tenderResult = await this.tenderResultService.getOne(params.id);
+
+    return { data: tenderResult }
+  }
+
+  @Post()
+  async createOne(
+    @Body() data: CreateResultBody,
+  ) {
+    const result = await this.tenderResultService.createOne(data);
+
+    return { data: result }
+  }
+
+  @Patch(':id')
+  async updateOne(
+    @Param() params: IdParams,
+    @Body() data: UpdateResultBody,
+  ) {
+    const result = await this.tenderResultService.updateOne(params.id, data);
+
+    return { data: result }
+  }
+
+  @Delete(':id')
+  async deleteOne(
+    @Param() params: IdParams,
+  ) {
+    const tenderResult = await this.tenderResultService.deleteOne(params.id);
+
+    return { data: tenderResult }
+  }
+
+}

--- a/src/module/tender-result/tender-result.module.ts
+++ b/src/module/tender-result/tender-result.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { TenderResultService } from './tender-result.service';
+import { TenderResultController } from './tender-result.controller';
+import { DatabaseModule } from 'src/core/module/database.module';
+import { TenderResult } from 'src/models/tender-result.entity';
+
+@Module({
+  imports: [
+    DatabaseModule.forFeature([TenderResult])
+  ],
+  controllers: [TenderResultController],
+  providers: [TenderResultService],
+})
+export class TenderResultModule { }

--- a/src/module/tender-result/tender-result.service.ts
+++ b/src/module/tender-result/tender-result.service.ts
@@ -1,0 +1,93 @@
+import { Injectable } from '@nestjs/common';
+import { InjectModel } from '@nestjs/mongoose';
+import { Model, Types, UpdateResult } from 'mongoose';
+import { MongoRepository } from 'src/core/helpers/mongo.helper';
+import { TenderResult } from 'src/models/tender-result.entity';
+import { TenderResultFilterArgs } from './args/result-filter.args';
+import { FilterArgs, PaginationArg } from 'src/core/shared/args/pagination.arg';
+import { CreateResultArgs, UpdateResultArgs } from './args/result-details.args';
+
+@Injectable()
+export class TenderResultService {
+    private readonly tenderResultRepo: MongoRepository<TenderResult>
+
+    constructor(
+        @InjectModel(TenderResult.name) private readonly tenderResultModel: Model<TenderResult>
+    ) {
+        this.tenderResultRepo = new MongoRepository<TenderResult>(this.tenderResultModel);
+    }
+
+    async getAll(
+        resultFilter: TenderResultFilterArgs,
+        filters: FilterArgs,
+        pagination: PaginationArg,
+
+    ) {
+        const { publishedAfter, region, tender, type } = resultFilter;
+        const { fields, keyword, sort } = filters;
+        return this.tenderResultRepo.findWithPagination({
+            filter: {
+                title: { $regex: keyword, $options: 'i' },
+                publishedDate: { $gte: publishedAfter },
+                region: region,
+                type: type,
+                tender: tender,
+            },
+            options: { sort: { [sort || 'createdAt']: -1 }, fields },
+            populate: ['tender']
+        }, pagination)
+    }
+
+    async getOne(id: Types.ObjectId) {
+        return this.tenderResultRepo.findOne({ _id: id }, {}, {}, ['tender', 'sources.newsPaper']);
+    }
+
+    async deleteOne(id: Types.ObjectId) {
+        return this.tenderResultRepo.deleteOne({ _id: id });
+    }
+
+    async createOne(data: CreateResultArgs) {
+        return this.tenderResultRepo.create(data);
+    }
+
+    async updateOne(id: Types.ObjectId, data: UpdateResultArgs) {
+        const { publishedDate, region, sources, tender, title, type } = data;
+
+        const result = await this.tenderResultRepo.findOne({ _id: id });
+
+        if (publishedDate) result.publishedDate = publishedDate;
+        if (region) result.region = region;
+        if (tender) result.tender = tender as any;
+        if (title) result.title = title;
+        if (type) result.type = type;
+        if (sources) {
+            sources.forEach(source => {
+                const index = result.sources.findIndex(s => source.newsPaper.equals(s.newsPaper._id));
+                if (index === -1 && source.imagesToAdd && source.imagesToAdd.length > 0) {
+                    result.sources.push({
+                        newsPaper: source.newsPaper as any,
+                        images: source.imagesToAdd,
+                    });
+                } else {
+                    if (source.imagesToAdd) {
+                        result.sources[index].images.push(...source.imagesToAdd);
+                    }
+                    if (source.imagesToRemove) {
+                        result.sources[index].images = result.sources[index].images.filter(i => !source.imagesToRemove.includes(i));
+
+                        if (result.sources[index].images.length === 0) {
+                            result.sources.splice(index, 1);
+                        }
+                    }
+
+                    result.markModified('sources');
+                }
+            })
+        }
+
+        if (result.isModified()) await result.save();
+        return await result.populate(['tender', 'sources.newsPaper']);
+    }
+
+
+}

--- a/src/module/tender/dto/update-tender.dto.ts
+++ b/src/module/tender/dto/update-tender.dto.ts
@@ -31,6 +31,10 @@ class SourceDTO {
 
 export class UpdateTenderBody extends PartialType(OmitType(CreateTenderBody, ['sources'] as const)) {
 
+    /**
+     * The sources of the tender
+     */
+    @IsOptional()
     @ValidateNested({ each: true })
     @Type(() => SourceDTO)
     sources?: SourceDTO[];


### PR DESCRIPTION
Introduce the TenderResult entity with its properties and relationships to Tender and NewsPaper. Implement the TenderResult module, including CRUD operations and necessary DTOs, args, and controller.